### PR TITLE
Add ReIgnite Mode and Option to Reignite

### DIFF
--- a/adc_prototype.py
+++ b/adc_prototype.py
@@ -22,7 +22,7 @@ class ReadADC:
 		self.SetProfiles(grill_probe_profile, probe_01_profile, probe_02_profile)
 
 		self.adc_data = {}
-		self.adc_data['GrillTemp'] = 125	# Fake starting temperature for prototype only
+		self.adc_data['GrillTemp'] = 55		# Fake starting temperature for prototype only
 		self.adc_data['Probe1Temp'] = 32	# Fake starting temperature for prototype only
 		self.adc_data['Probe2Temp'] = 42	# Fake starting temperature for prototype only
 
@@ -33,44 +33,9 @@ class ReadADC:
 
 	def adctotemp(self, adc_value, probe_profile):
 		# Since this is just a prototype module, and data is simulated, this function is not used. 
-		if(adc_value > 0) and (adc_value < (probe_profile['Vs'] * 1000)):
-			# Voltage at the divider (i.e. input to the ADC)
-			Vo = (adc_value / 1000) # mV to V of ADC (at the divider)
-
-			# Thermistor Resistor Value Ohms (R1)
-			# R1 = ( (Vin * R2) - (Vout * R2) ) / Vout
-			# Tr = ((probe_profile['Vs'] * probe_profile['Rd']) - (Vo * probe_profile['Rd'])) / Vo
-			# R2 = ( Vout * R1 ) / ( Vin - Vout )
-			Tr = ( Vo * probe_profile['Rd']) / ( probe_profile['Vs'] - Vo )
-
-			# Coefficient a, b, & c values
-
-			a = probe_profile['A']
-			b = probe_profile['B']
-			c = probe_profile['C']
-
-		    #Steinhart Hart Equation
-
-			# 1/T = A + B(ln(R)) + C(ln(R))^3
-
-		    # T = 1/(a + b[ln(ohm)] + c[ln(ohm)]^3)
-
-			lnohm = math.log(Tr) # ln(ohms)
-
-			t1 = (b*lnohm) # b[ln(ohm)]
-
-			t2 = c * math.pow(lnohm,3) # c[ln(ohm)]^3
-
-			tempK = 1/(a + t1 + t2) # calculate temperature in Kelvin
-
-			tempC = tempK - 273.15 # Kelvin to Celsius
-
-			tempF = tempC * (9/5) + 32 # Celsius to Farenheit
-
-		else:
-			tempF = 0.0
-
-		return tempF
+		tempF = 100
+		Tr = 1000
+		return tempF, Tr 
 
 	def ReadAllPorts(self):
 		# This is my attemp at making a psuedo-random temperature that will generally rise
@@ -81,7 +46,7 @@ class ReadADC:
 
 		if (adc_value[0] > 7) and (self.adc_data['GrillTemp'] < 425):
 			self.adc_data['GrillTemp'] += 1 # raise temperature by 1 degree
-		elif (adc_value[0] < 1) and (self.adc_data['GrillTemp'] > 125):
+		elif (adc_value[0] < 1) and (self.adc_data['GrillTemp'] > 50):
 			self.adc_data['GrillTemp'] -= 1 # reduce temperature by 1 degree
 
 		if (adc_value[1] > 7) and (self.adc_data['Probe1Temp'] < 200):

--- a/app.py
+++ b/app.py
@@ -550,6 +550,9 @@ def settingspage(action=None):
 		if('maxstartuptemp' in response):
 			if(response['maxstartuptemp'] != ''):
 				settings['safety']['maxstartuptemp'] = int(response['maxstartuptemp'])
+		if('reigniteretries' in response):
+			if(response['reigniteretries'] != ''):
+				settings['safety']['reigniteretries'] = int(response['reigniteretries'])
 		if('maxtemp' in response):
 			if(response['maxtemp'] != ''):
 				settings['safety']['maxtemp'] = int(response['maxtemp'])

--- a/common.py
+++ b/common.py
@@ -66,7 +66,7 @@ def DefaultSettings():
 		'minstartuptemp' : 75, # User Defined. Minimum temperature allowed for startup.
 		'maxstartuptemp' : 100, # User Defined. Take this value if the startup temp is higher than maxstartuptemp
 		'maxtemp' : 500, # User Defined. If temp exceeds this value in any mode, shut off.  (including monitor mode)
-		'reignitetries' : 0, # Number of tries to reignite the grill if it has gone below the safe temperature (set to 0 to disable) (TODO)
+		'reigniteretries' : 1, # Number of tries to reignite the grill if it has gone below the safe temperature (set to 0 to disable)
 	}
 
 	settings['page_theme'] = 'light'
@@ -74,6 +74,9 @@ def DefaultSettings():
 	return settings
 
 def DefaultControl():
+
+	settings = ReadSettings()
+
 	control = {}
 
 	control['updated'] = True
@@ -118,6 +121,8 @@ def DefaultControl():
 	control['safety'] = {
 		'startuptemp' : 0, # Set by control function at startup
 		'afterstarttemp' : 0, # Set by control function during startup
+		'reigniteretries' : settings['safety']['reigniteretries'], # Set by user to attempt a re-ignite when the grill drops below a certain temp
+		'reignitelaststate' : 'Smoke' # Set by control function to remember the last state we were in when the temp dropped below safety levels 
 	}
 
 	return(control)

--- a/templates/data.html
+++ b/templates/data.html
@@ -17,7 +17,7 @@
 
 			{% else %}
 
-				{% if (current_mode == 'Startup') %}
+				{% if (current_mode == 'Startup') or (current_mode == 'Reignite') %}
 				<button type="submit" class="btn btn-success border border-secondary" name="setmodestartup" value="true"><i class="fas fa-play"></i></button>
 				{% endif %}
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -508,12 +508,19 @@
 						</div>
 						<div class="input-group mb-3">
 							<div class="input-group-prepend">
+								<span class="input-group-text" data-toggle="tooltip" title="Number of retries to attempt re-ignite after the grill temperature goes too low. Set to zero to disable. [default=1]"><i class="fas fa-redo-alt"></i>&nbsp; Reignite Retries</span>
+							</div>
+							<input id="reigniteretries" type="number" min="0" max="10" class="form-control" placeholder="{{ settings['safety']['reigniteretries'] }}" value="{{ settings['safety']['reigniteretries'] }}" name="reigniteretries">
+						</div>
+
+						<div class="input-group mb-3">
+							<div class="input-group-prepend">
 								<span class="input-group-text" data-toggle="tooltip" title="Maximum allowable temperature.  Shut down grill to prevent potential damage."><i class="fas fa-temperature-high"></i>&nbsp; Max Operational Temp (F)</span>
 							</div>
 							<input id="maxtemp" type="number" min="1" class="form-control" placeholder="{{ settings['safety']['maxtemp'] }}" value="{{ settings['safety']['mintemp'] }}" name="maxtemp">
 						</div>
 						<br>
-						<i><b>Note:</b> In an error condition (temp too low, temp too high) the grill will immediately shutdown and log the error in the events log.  Notifications of an error will be sent if enabled.  Safety features are also enabled in Monitor mode.</i><br>
+						<i><b>Note:</b> In an error condition (temp too low, temp too high) the grill will immediately shutdown and log the error in the events log.  Notifications of an error will be sent if enabled.  The Max Temp safety setting is also enabled in Monitor mode.</i><br>
 						<i><b class="text-danger">Warning:</b> Safety features are not infallible and may not prevent safety issues with your grill in all cases.  As with any grill, it is the operator's responsibility to monitor their equipment to ensure proper operational safety.</i>
 					</div> <!-- End of card body -->
 					<div class="card-footer bg-light">


### PR DESCRIPTION
Add ReIgnite Mode and Option to Reignite when temperature of the grill drops below minimum range.  You can attempt to reignite up to 10 times before a failure occurs.  Added to Safety Settings on the Settings page.   If using a previous version of PiFire, requires an update to your settings file to include the new setting.  This may mean that you will need to delete your settings file (or reset to factory settings) to get the new option setup.