### PR TITLE
Added option for HIGH or LOW level buttons.

### DIFF
--- a/common.py
+++ b/common.py
@@ -41,6 +41,7 @@ def DefaultSettings():
 		'debug_mode' : False,
 		'page_theme' : 'light',
 		'triggerlevel' : 'LOW',
+		'buttonslevel' : 'HIGH',
 		'units' : 'F'
 	}
 

--- a/control.py
+++ b/control.py
@@ -1020,6 +1020,7 @@ settings = ReadSettings()
 outpins = settings['outpins']
 inpins = settings['inpins']
 triggerlevel = settings['globals']['triggerlevel']
+buttonslevel = settings['globals']['buttonslevel']
 
 if triggerlevel == 'LOW':
 	AUGERON = 0
@@ -1040,7 +1041,10 @@ else:
 	grill_platform.PowerOff()
 
 # Start display device object and display splash
-display_device = Display()
+if(str(settings['modules']['display']).endswith('b')):	
+	display_device = Display(buttonslevel)
+else:
+	display_device = Display()
 
 grill0type = settings['probe_types']['grill0type']
 probe1type = settings['probe_types']['probe1type']

--- a/display_ili9341b.py
+++ b/display_ili9341b.py
@@ -31,7 +31,7 @@ from common import ReadControl, WriteControl  # Common Library for WebUI and Con
 
 class Display:
 
-	def __init__(self):
+	def __init__(self, buttonslevel='HIGH'):
 		# Set Display Width and Height.  Modify for your needs.   
 		self.WIDTH = 320
 		self.HEIGHT = 240
@@ -50,7 +50,15 @@ class Display:
 
 		#GPIO.add_event_detect(self.up, GPIO.FALLING, callback=self.UpCallback, bouncetime=300)  
 		#GPIO.add_event_detect(self.down, GPIO.FALLING, callback=self.DownCallback, bouncetime=300) 
-		#GPIO.add_event_detect(self.enter, GPIO.FALLING, callback=self.EnterCallback, bouncetime=300) 
+		#GPIO.add_event_detect(self.enter, GPIO.FALLING, callback=self.EnterCallback, bouncetime=300)
+
+		# ==== Buttons Setup =====
+		if buttonslevel == 'HIGH':
+				# Defines for input buttons level HIGH
+				self.BUTTON_INPUT = 0
+		else:
+				# Defines for input buttons level LOW
+				self.BUTTON_INPUT = 1
 
 		# ==== Menu Setup =====
 		self.displayactive = False
@@ -365,13 +373,13 @@ class Display:
 	# ====================== Menu Code ========================
 
 	def EventDetect(self):
-		if(GPIO.input(self.up) == 1):
+		if(GPIO.input(self.up) == self.BUTTON_INPUT):
 			self.UpCallback(self.up)
 
-		if(GPIO.input(self.down) == 1):
+		if(GPIO.input(self.down) == self.BUTTON_INPUT):
 			self.DownCallback(self.down)
 
-		if(GPIO.input(self.enter) == 1):
+		if(GPIO.input(self.enter) == self.BUTTON_INPUT):
 			self.EnterCallback(self.enter)
 
 		if(self.displayactive == False) and (time.time() - self.menutime > 5) and (self.menuactive == True):

--- a/display_ili9341b.py
+++ b/display_ili9341b.py
@@ -54,11 +54,11 @@ class Display:
 
 		# ==== Buttons Setup =====
 		if buttonslevel == 'HIGH':
-				# Defines for input buttons level HIGH
-				self.BUTTON_INPUT = 0
+			# Defines for input buttons level HIGH
+			self.BUTTON_INPUT = 0
 		else:
-				# Defines for input buttons level LOW
-				self.BUTTON_INPUT = 1
+			# Defines for input buttons level LOW
+			self.BUTTON_INPUT = 1
 
 		# ==== Menu Setup =====
 		self.displayactive = False

--- a/display_pygame_240x320b.py
+++ b/display_pygame_240x320b.py
@@ -48,11 +48,11 @@ class Display:
 
 		# ==== Buttons Setup =====
 		if buttonslevel == 'HIGH':
-				# Defines for input buttons level HIGH
-				self.BUTTON_INPUT = 0
+			# Defines for input buttons level HIGH
+			self.BUTTON_INPUT = 0
 		else:
-				# Defines for input buttons level LOW
-				self.BUTTON_INPUT = 1 
+			# Defines for input buttons level LOW
+			self.BUTTON_INPUT = 1
 
 		# ==== Menu Setup =====
 		self.displayactive = False

--- a/display_pygame_240x320b.py
+++ b/display_pygame_240x320b.py
@@ -30,7 +30,7 @@ from common import ReadControl, WriteControl  # Common Library for WebUI and Con
 
 class Display:
 
-	def __init__(self):
+	def __init__(self, buttonslevel='HIGH'):
 		# Set Display Width and Height.  Modify for your needs.   
 		self.WIDTH = 320
 		self.HEIGHT = 240
@@ -44,7 +44,15 @@ class Display:
 		pygame.display.set_caption('PiFire Device Display')
 
 		self.DisplaySplash()
-		time.sleep(0.5) # Keep the splash up for three seconds on boot-up - you can certainly disable this if you want 
+		time.sleep(0.5) # Keep the splash up for three seconds on boot-up - you can certainly disable this if you want
+
+		# ==== Buttons Setup =====
+		if buttonslevel == 'HIGH':
+				# Defines for input buttons level HIGH
+				self.BUTTON_INPUT = 0
+		else:
+				# Defines for input buttons level LOW
+				self.BUTTON_INPUT = 1 
 
 		# ==== Menu Setup =====
 		self.displayactive = False

--- a/display_ssd1306b.py
+++ b/display_ssd1306b.py
@@ -22,7 +22,7 @@ from common import ReadControl, WriteControl  # Common Library for WebUI and Con
 
 class Display:
 
-	def __init__(self):
+	def __init__(self, buttonslevel='HIGH'):
 		self.serial = i2c(port=1, address=0x3C)
 		self.device = ssd1306(self.serial)
 		self.menuactive = False
@@ -40,7 +40,15 @@ class Display:
 
 		#GPIO.add_event_detect(self.up, GPIO.FALLING, callback=self.UpCallback, bouncetime=300)  
 		#GPIO.add_event_detect(self.down, GPIO.FALLING, callback=self.DownCallback, bouncetime=300) 
-		#GPIO.add_event_detect(self.enter, GPIO.FALLING, callback=self.EnterCallback, bouncetime=300) 
+		#GPIO.add_event_detect(self.enter, GPIO.FALLING, callback=self.EnterCallback, bouncetime=300)
+
+		# ==== Buttons Setup =====
+		if buttonslevel == 'HIGH':
+				# Defines for input buttons level HIGH
+				self.BUTTON_INPUT = 0
+		else:
+				# Defines for input buttons level LOW
+				self.BUTTON_INPUT = 1 
 
 		self.menu = {}
 
@@ -175,13 +183,13 @@ class Display:
 	# OnScreen Menu Controls
 
 	def EventDetect(self):
-		if(GPIO.input(self.up) == 1):
+		if(GPIO.input(self.up) == self.BUTTON_INPUT):
 			self.UpCallback(self.up)
 
-		if(GPIO.input(self.down) == 1):
+		if(GPIO.input(self.down) == self.BUTTON_INPUT):
 			self.DownCallback(self.down)
 
-		if(GPIO.input(self.enter) == 1):
+		if(GPIO.input(self.enter) == self.BUTTON_INPUT):
 			self.EnterCallback(self.enter)
 
 	def UpCallback(self, pin):

--- a/display_ssd1306b.py
+++ b/display_ssd1306b.py
@@ -44,11 +44,11 @@ class Display:
 
 		# ==== Buttons Setup =====
 		if buttonslevel == 'HIGH':
-				# Defines for input buttons level HIGH
-				self.BUTTON_INPUT = 0
+			# Defines for input buttons level HIGH
+			self.BUTTON_INPUT = 0
 		else:
-				# Defines for input buttons level LOW
-				self.BUTTON_INPUT = 1 
+			# Defines for input buttons level LOW
+			self.BUTTON_INPUT = 1
 
 		self.menu = {}
 


### PR DESCRIPTION
Added option for HIGH or LOW level buttons.
If your using pull downs for the buttons, you can modify your
settings.json file to indicate LOW level

In the settings.json file, make sure to edit the
'globals' 'buttonslevel' value from 'HIGH' to 'LOW'.

e.g.

"globals": {
    "grill_name": "",
    "debug_mode": false,
    "page_theme": "light",
    "triggerlevel": "LOW",
    "buttonslevel": "LOW",
    "units": "F"
  },