### PR TITLE
Add thread lock for SocketIO emitGrillData 

### DIFF
--- a/common.py
+++ b/common.py
@@ -47,6 +47,7 @@ def DefaultSettings():
 		'triggerlevel' : 'LOW',
 		'buttonslevel' : 'HIGH',
 		'shutdown_timer' : 60,
+		'four_probes' : False,
 		'units' : 'F'
 	}
 


### PR DESCRIPTION
and a force refresh option. Since we are emitting the same data to every client there
is no need to have multiple threads. Force refresh will help with client
disconnects and pull to refresh in the Android Dashboard
Also moved probe config to the server. Android client will fetch this and show proper version. 