### PR TITLE
Bugfix for ili9341 display on pi zero 2. Added .idea to ant exclusions

### DIFF
--- a/display_ili9341.py
+++ b/display_ili9341.py
@@ -33,7 +33,7 @@ class Display:
 		self.WIDTH = 320
 		self.HEIGHT = 240
 		# Init Device
-		self.serial = spi(port=0, device=0, gpio_DC=24, gpio_RST=25)
+		self.serial = spi(port=0, device=0, gpio_DC=24, gpio_RST=25, bus_speed_hz=32000000, reset_hold_time=0.2, reset_release_time=0.2)
 		self.device = ili9341(self.serial, active_low=False, width=self.WIDTH, height=self.HEIGHT, gpio_LIGHT=5)
 		self.DisplaySplash()
 		time.sleep(0.5) # Keep the splash up for three seconds on boot-up - you can certainly disable this if you want 

--- a/display_ili9341b.py
+++ b/display_ili9341b.py
@@ -38,7 +38,7 @@ class Display:
 		self.WIDTH = 320
 		self.HEIGHT = 240
 		# Init Device
-		self.serial = spi(port=0, device=0, gpio_DC=24, gpio_RST=25)
+		self.serial = spi(port=0, device=0, gpio_DC=24, gpio_RST=25, bus_speed_hz=32000000, reset_hold_time=0.2, reset_release_time=0.2)
 		self.device = ili9341(self.serial, active_low=False, width=self.WIDTH, height=self.HEIGHT, gpio_LIGHT=5)
 		# Init GPIO for button input, setup callbacks: Uncomment to utilize GPIO input
 		self.up = 16 	# UP - GPIO16

--- a/installer/debian/build.xml
+++ b/installer/debian/build.xml
@@ -47,6 +47,7 @@
                 <exclude name="venv/**"/>
                 <exclude name="docs/**"/>
                 <exclude name="auto-install/**"/>
+                <exclude name=".idea/**"/>
                 <exclude name=".gitignore"/>
                 <exclude name="build.xml"/>
                 <exclude name="*.nginx"/>


### PR DESCRIPTION
Bugfix for ili9341 display and pi zero 2 w. Added reset_hold_time and reset_release_time to solve lines issues on display. Added bus_speed_hz to improve refresh rate. Add .idea folder exclusion to ant build script.