### PR TITLE
Update to Manual Mode. Add manual mode support to Android app. 

### DIFF
--- a/app.py
+++ b/app.py
@@ -1088,52 +1088,41 @@ def manual_page(action=None):
 			if(response['setmode']=='manual'):
 				control['updated'] = True
 				control['mode'] = 'Manual'
-				WriteControl(control)
+			else:
+				control['updated'] = True
+				control['mode'] = 'Stop'
 
 		if('change_output_fan' in response):
 			if(response['change_output_fan']=='on'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'fan'
-				control['manual']['state'] = 'on'
-				WriteControl(control)
+				control['manual']['fan'] = True
 			elif(response['change_output_fan']=='off'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'fan'
-				control['manual']['state'] = 'off'
-				WriteControl(control)
+				control['manual']['fan'] = False
 		elif('change_output_auger' in response):
 			if(response['change_output_auger']=='on'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'auger'
-				control['manual']['state'] = 'on'
-				WriteControl(control)
+				control['manual']['auger'] = True
 			elif(response['change_output_auger']=='off'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'auger'
-				control['manual']['state'] = 'off'
-				WriteControl(control)
+				control['manual']['auger'] = False
 		elif('change_output_igniter' in response):
 			if(response['change_output_igniter']=='on'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'igniter'
-				control['manual']['state'] = 'on'
-				WriteControl(control)
+				control['manual']['igniter'] = True
 			elif(response['change_output_igniter']=='off'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'igniter'
-				control['manual']['state'] = 'off'
-				WriteControl(control)
+				control['manual']['igniter'] = False
 		elif('change_output_power' in response):
 			if(response['change_output_power']=='on'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'power'
-				control['manual']['state'] = 'on'
-				WriteControl(control)
+				control['manual']['power'] = True
 			elif(response['change_output_power']=='off'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'power'
-				control['manual']['state'] = 'off'
-				WriteControl(control)
+				control['manual']['power'] = False
+
+		WriteControl(control)
+
 		time.sleep(1)
 		control = ReadControl()
 
@@ -1498,6 +1487,24 @@ def request_info_data():
 	}
 
 	return info_list
+
+@socketio.on('request_manual_data')
+def request_manual_data():
+	settings = ReadSettings()
+	control = ReadControl()
+
+	if(settings['modules']['grillplat'] == 'prototype'):
+		print('Client requesting manual data')
+
+	manual = control['manual']
+	mode = control['mode']
+
+	manual_list = {
+		'manual' : manual,
+		'mode' : mode
+	}
+
+	return manual_list
 		
 @socketio.on('update_control_data')
 def update_control(json_data):
@@ -2068,42 +2075,34 @@ def update_manual_data(json_data):
 		if('change_output_fan' in data['manual']):
 			if(data['manual']['change_output_fan']=='true'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'fan'
-				control['manual']['state'] = 'on'
+				control['manual']['fan'] = True
 			elif(data['manual']['change_output_fan']=='false'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'fan'
-				control['manual']['state'] = 'off'
+				control['manual']['fan'] = False
 
 		if('change_output_auger' in data['manual']):
 			if(data['manual']['change_output_auger']=='true'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'auger'
-				control['manual']['state'] = 'on'
+				control['manual']['auger'] = True
 			elif(data['manual']['change_output_auger']=='false'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'auger'
-				control['manual']['state'] = 'off'
+				control['manual']['auger'] = False
 
 		if('change_output_igniter' in data['manual']):
 			if(data['manual']['change_output_igniter']=='true'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'igniter'
-				control['manual']['state'] = 'on'
+				control['manual']['igniter'] = True
 			elif(data['manual']['change_output_igniter']=='false'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'igniter'
-				control['manual']['state'] = 'off'
+				control['manual']['igniter'] = False
 
 		if('change_output_power' in data['manual']):
 			if(data['manual']['change_output_power']=='true'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'power'
-				control['manual']['state'] = 'on'
+				control['manual']['power'] = True
 			elif(data['manual']['change_output_power']=='false'):
 				control['manual']['change'] = True
-				control['manual']['output'] = 'power'
-				control['manual']['state'] = 'off'
+				control['manual']['power'] = False
 
 		WriteControl(control)
 

--- a/common.py
+++ b/common.py
@@ -31,9 +31,8 @@ cmdsts = redis.StrictRedis('localhost', 6379, charset="utf-8", decode_responses=
 def DefaultSettings():
 	settings = {}
 
-	settings['versions'] = { 
-		'android' : 5,
-		'server' : 1
+	settings['versions'] = {
+		'server' : "1.0.0"
 	}
 
 	settings['history_page'] = {
@@ -217,16 +216,11 @@ def DefaultControl():
 
 	control['manual'] = {
 		'change' : False,
-		'output' : '',
-		'state' : ''
+		'fan' : False,
+		'auger' : False,
+		'igniter' : False,
+		'power' : False
 	}
-
-	control['manual']['current'] = {
-			'fan' : 1,
-			'auger' : 1,
-			'igniter' : 1,
-			'power' : 1
-		}
 
 	return(control)
 

--- a/control.py
+++ b/control.py
@@ -740,35 +740,33 @@ def Manual_Mode(grill_platform, adc_device, display_device, dist_device):
 				WriteControl(control)
 				break
 
-		if (control['manual']['change'] == True):
-			if (control['manual']['output'] == 'fan'):
-				if (control['manual']['state'] == 'on'):
-					grill_platform.FanOn()
-				else:
-					grill_platform.FanOff()
-			if (control['manual']['output'] == 'auger'):
-				if (control['manual']['state'] == 'on'):
-					grill_platform.AugerOn()
-				else:
-					grill_platform.AugerOff()
-			if (control['manual']['output'] == 'igniter'):
-				if (control['manual']['state'] == 'on'):
-					grill_platform.IgniterOn()
-				else:
-					grill_platform.IgniterOff()
-			if (control['manual']['output'] == 'power'):
-				if (control['manual']['state'] == 'on'):
-					grill_platform.PowerOn()
-				else:
-					grill_platform.PowerOff()
+		# Get current grill output status
+		current_output_status = grill_platform.GetOutputStatus()
+
+		if(control['manual']['change'] == True):
+			if(control['manual']['fan'] == True) and (current_output_status['fan'] == FANOFF):
+				grill_platform.FanOn()
+			elif(control['manual']['fan'] == False) and (current_output_status['fan'] == FANON):
+				grill_platform.FanOff()
+
+			if(control['manual']['auger'] == True) and (current_output_status['auger'] == AUGEROFF):
+				grill_platform.AugerOn()
+			elif(control['manual']['auger'] == False) and (current_output_status['auger'] == AUGERON):
+				grill_platform.AugerOff()
+
+			if(control['manual']['igniter'] == True) and (current_output_status['igniter'] == IGNITEROFF):
+				grill_platform.IgniterOn()
+			elif(control['manual']['igniter'] == False) and (current_output_status['igniter'] == IGNITERON):
+				grill_platform.IgniterOff()
+
+			if(control['manual']['power'] == True) and (current_output_status['power'] == POWEROFF):
+				grill_platform.PowerOn()
+			elif(control['manual']['power'] == False) and (current_output_status['power'] == POWERON):
+				grill_platform.PowerOff()
+
 			#control = ReadControl()  # Read Modify Write
 			control['manual']['change'] = False
 			WriteControl(control)
-
-		#control = ReadControl()  # Read Modify Write
-		control['manual']['current'] = not grill_platform.GetOutputStatus()
-
-		WriteControl(control)
 
 		# Grab current probe profiles if they have changed since the last loop. 
 		if (control['probe_profile_update'] == True):
@@ -814,7 +812,13 @@ def Manual_Mode(grill_platform, adc_device, display_device, dist_device):
 			temptoggletime = time.time()
 			WriteHistory(in_data)
 
-		time.sleep(0.1)
+		time.sleep(0.2)
+
+	# Clean-up and Exit
+	grill_platform.AugerOff()
+	grill_platform.IgniterOff()
+	grill_platform.FanOff()
+	grill_platform.PowerOff()
 
 	event = 'Manual mode ended.'
 	WriteLog(event)
@@ -1195,11 +1199,21 @@ buttonslevel = settings['globals']['buttonslevel']
 if triggerlevel == 'LOW':
 	AUGERON = 0
 	AUGEROFF = 1
+	FANON = 0
 	FANOFF = 1
+	IGNITERON = 0
+	IGNITEROFF = 1
+	POWERON = 0
+	POWEROFF = 1
 else:
 	AUGERON = 1
 	AUGEROFF = 0
+	FANON = 1
 	FANOFF = 0
+	IGNITERON = 1
+	IGNITEROFF = 0
+	POWERON = 1
+	POWEROFF = 0
 
 # Initialize Grill Platform Object
 grill_platform = GrillPlatform(outpins, inpins, triggerlevel)

--- a/templates/manual.html
+++ b/templates/manual.html
@@ -1,6 +1,6 @@
-{% extends 'base.html' %} 
+{% extends 'base.html' %}
 
-{% block title %}Manual Control{% endblock %} 
+{% block title %}Manual Control{% endblock %}
 
 {% block content %}
 	<div class="row">
@@ -10,7 +10,7 @@
 			<div class="card-body">
 					<form name="ManualMode" method="POST">
 						{% if control['mode'] == 'Manual' %}
-						<button type="submit" class="btn btn-success btn-block shadow" name="setmode" value="manual">Manual Mode Selected</button>
+						<button type="submit" class="btn btn-success btn-block shadow" name="setmode" value="stop">Manual Mode Selected</button>
 						{% else %}
 						<button type="submit" class="btn btn-secondary btn-block shadow" name="setmode" value="manual">Turn on Manual Mode</button>
 						{% endif %}
@@ -21,28 +21,28 @@
 					{% if control['mode'] == 'Manual' %}
 					<form name="ChangeValues" method="POST">
 						<div class="btn-group">
-							{% if control['manual']['current']['fan'] == 0 %}
-							<button type="submit" data-toggle="tooltip" title="FAN" class="btn btn-primary" name="change_output_fan" value='off'><i class="fas fa-fan"></i></button>
-							{% else %}
+							{% if control['manual']['fan'] == False %}
 							<button type="submit" data-toggle="tooltip" title="FAN" class="btn btn-outline-primary" name="change_output_fan" value='on'><i class="fas fa-fan"></i></button>
+							{% else %}
+							<button type="submit" data-toggle="tooltip" title="FAN" class="btn btn-primary" name="change_output_fan" value='off'><i class="fas fa-fan"></i></button>
 							{% endif %}
 
-							{% if control['manual']['current']['auger'] == 0 %}
-							<button type="submit" data-toggle="tooltip" title="AUGER" class="btn btn-primary" name="change_output_auger" value='off'><i class="fas fa-play-circle"></i></button>
-							{% else %}
+							{% if control['manual']['auger'] == False %}
 							<button type="submit" data-toggle="tooltip" title="AUGER" class="btn btn-outline-primary" name="change_output_auger" value='on'><i class="fas fa-play-circle"></i></button>
+							{% else %}
+							<button type="submit" data-toggle="tooltip" title="AUGER" class="btn btn-primary" name="change_output_auger" value='off'><i class="fas fa-play-circle"></i></button>
 							{% endif %}
 
-							{% if control['manual']['current']['igniter'] == 0 %}
-							<button type="submit" data-toggle="tooltip" title="IGNITER" class="btn btn-primary" name="change_output_igniter" value='off'><i class="fas fa-fire"></i></button>
-							{% else %}
+							{% if control['manual']['igniter'] == False %}
 							<button type="submit" data-toggle="tooltip" title="IGNITER" class="btn btn-outline-primary" name="change_output_igniter" value='on'><i class="fas fa-fire"></i></button>
+							{% else %}
+							<button type="submit" data-toggle="tooltip" title="IGNITER" class="btn btn-primary" name="change_output_igniter" value='off'><i class="fas fa-fire"></i></button>
 							{% endif %}
 
-							{% if control['manual']['current']['power'] == 0 %}
-							<button type="submit" data-toggle="tooltip" title="POWER" class="btn btn-primary" name="change_output_power" value='off'><i class="fas fa-power-off"></i></button>
-							{% else %}
+							{% if control['manual']['power'] == False %}
 							<button type="submit" data-toggle="tooltip" title="POWER" class="btn btn-outline-primary" name="change_output_power" value='on'><i class="fas fa-power-off"></i></button>
+							{% else %}
+							<button type="submit" data-toggle="tooltip" title="POWER" class="btn btn-primary" name="change_output_power" value='off'><i class="fas fa-power-off"></i></button>
 							{% endif %}
 						</div>
 					</form>

--- a/version.xml
+++ b/version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <server>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 </server>


### PR DESCRIPTION
I could never really get manual mode to work right before. Sometimes it would trigger the relays other times it wouldn't. I could also never get it out of manual mode unless pifire was restarted. So I updated manual mode to work more consistently. Added manual mode data to SocketIO for android support. Removed android version in favor of using only server version to check for feature support in android app.

I did some light testing on the physical grill and it was working great. 