### PR TITLE
Add Socket IO Backup/Restore functions, PID Center setting, Update distance prototype, Update ant install script

### DIFF
--- a/app.py
+++ b/app.py
@@ -1595,6 +1595,107 @@ def request_manual_data():
 	}
 
 	return manual_list
+
+@socketio.on('request_backup_list')
+def request_backup_list(type='settings'):
+	settings = ReadSettings()
+
+	if (settings['modules']['grillplat'] == 'prototype'):
+		print('Client requesting restore file list')
+
+	files = os.listdir(BACKUPPATH)
+	for file in files[:]:
+		if not allowed_file(file):
+			files.remove(file)
+
+	print(f'Files List: {files}')
+
+	if (type == 'settings'):
+		for file in files[:]:
+			if not file.startswith('PiFire_'):
+				files.remove(file)
+
+		return json.dumps(files)
+
+	if (type == 'pelletdb'):
+		for file in files[:]:
+			if not file.startswith('PelletDB_'):
+				files.remove(file)
+
+		return json.dumps(files)
+
+@socketio.on('request_backup_data')
+def request_backup_data(type='settings'):
+	settings = ReadSettings()
+	pelletdb = ReadPelletDB()
+
+	if (settings['modules']['grillplat'] == 'prototype'):
+		print('Client requesting backup data')
+
+	timenow = datetime.datetime.now()
+	timestr = timenow.strftime('%m-%d-%y_%H%M%S') # Truncate the microseconds
+
+	if (type == 'settings'):
+		print('Backing up settings... ')
+		backupfile = BACKUPPATH + 'PiFire_' + timestr + '.json'
+		os.system(f'cp settings.json {backupfile}')
+		return settings
+
+	if (type == 'pelletdb'):
+		print('Backing up pelletdb... ')
+		backupfile = BACKUPPATH + 'PelletDB_' + timestr + '.json'
+		os.system(f'cp pelletdb.json {backupfile}')
+		return pelletdb
+
+@socketio.on('update_restore_data')
+def update_restore_data(type='settings', filename='none', json_data=None):
+	settings = ReadSettings()
+
+	if (settings['modules']['grillplat'] == 'prototype'):
+		print('Client requesting data restore')
+
+	timenow = datetime.datetime.now()
+	timestr = timenow.strftime('%m-%d-%y_%H%M%S') # Truncate the microseconds
+
+	if(type == 'settings'):
+		print('Restoring settings...')
+
+		if (filename != 'none'):
+			print(f'Selected local file: {BACKUPPATH+filename}')
+			settings = ReadSettings(filename=BACKUPPATH+filename)
+			return "success"
+		elif (json_data is not None):
+			print(f'Restoring remote settings json')
+			data = json.loads(json_data)
+			backupfile = BACKUPPATH + 'PiFire_' + timestr + '.json'
+			json_data_string = json.dumps(data, indent=2, sort_keys=True)
+			with open(backupfile, 'w') as settings_file:
+				settings_file.write(json_data_string)
+			settings = ReadSettings(filename=backupfile)
+			return "success"
+		else:
+			print('No filename in request.')
+			return "error"
+
+	if(type == 'pelletdb'):
+		print('Restoring pelletdb...')
+
+		if (filename != 'none'):
+			print(f'Selected local file: {BACKUPPATH+filename}')
+			settings = ReadPelletDB(filename=BACKUPPATH+filename)
+			return "success"
+		elif (json_data is not None):
+			print(f'Restoring remote pelletdb json')
+			data = json.loads(json_data)
+			backupfile = BACKUPPATH + 'PelletDB_' + timestr + '.json'
+			json_data_string = json.dumps(data, indent=2, sort_keys=True)
+			with open(backupfile, 'w') as pelletdb_file:
+				pelletdb_file.write(json_data_string)
+			settings = ReadPelletDB(filename=backupfile)
+			return "success"
+		else:
+			print('No filename in request.')
+			return "error"
 		
 @socketio.on('update_control_data')
 def update_control(json_data):

--- a/app.py
+++ b/app.py
@@ -871,6 +871,9 @@ def settingspage(action=None):
 		if('u_max' in response):
 			if(response['u_max'] != ''):
 				settings['cycle_data']['u_max'] = float(response['u_max'])
+		if('center' in response):
+			if(response['center'] != ''):
+				settings['cycle_data']['center'] = float(response['center'])
 		if('sp_cycle' in response):
 			if(response['sp_cycle'] != ''):
 				settings['smoke_plus']['cycle'] = int(response['sp_cycle'])
@@ -2038,6 +2041,9 @@ def update_settings(json_data):
 		if('u_max' in data['cycle']):
 			if(data['cycle']['u_max'] != ''):
 				settings['cycle_data']['u_max'] = float(data['cycle']['u_max'])
+		if('center' in data['cycle']):
+			if(data['cycle']['center'] != ''):
+				settings['cycle_data']['center'] = float(data['cycle']['center'])
 		if('sp_cycle' in data['cycle']):
 			if(data['cycle']['sp_cycle'] != ''):
 				settings['smoke_plus']['cycle'] = int(data['cycle']['sp_cycle'])
@@ -2117,6 +2123,23 @@ def update_settings(json_data):
 
 		if('full' in data['pellets']):
 			settings['pelletlevel']['full'] = int(data['pellets']['full'])
+
+	if ('units' in data):
+		if('temp_units' in data['units']):
+			if(data['units']['temp_units'] == 'C') and (settings['globals']['units'] == 'F'):
+				settings = convert_settings_units('C', settings)
+				WriteSettings(settings)
+				control = ReadControl()
+				control['updated'] = True
+				control['units_change'] = True
+				WriteControl(control)
+			elif(data['units']['temp_units'] == 'F') and (settings['globals']['units'] == 'C'):
+				settings = convert_settings_units('F', settings)
+				WriteSettings(settings)
+				control = ReadControl()
+				control['updated'] = True
+				control['units_change'] = True
+				WriteControl(control)
 
 	# Take all settings and write them
 	WriteSettings(settings)

--- a/common.py
+++ b/common.py
@@ -32,7 +32,7 @@ def DefaultSettings():
 	settings = {}
 
 	settings['versions'] = {
-		'server' : "1.0.0"
+		'server' : "1.2.2"
 	}
 
 	settings['history_page'] = {
@@ -111,7 +111,8 @@ def DefaultSettings():
 		'SmokeCycleTime' : 15,
 		'PMode' : 2,  # http://tipsforbbq.com/Definition/Traeger-P-Setting
 		'u_min' : 0.15,
-		'u_max' : 1.0
+		'u_max' : 1.0,
+		'center' : 0.5
 	}
 
 	settings['smoke_plus'] = {

--- a/distance_prototype.py
+++ b/distance_prototype.py
@@ -8,7 +8,7 @@
 #
 # *****************************************
 
-from common import WriteLog
+from common import WriteLog, ReadSettings
 import random
 
 class HopperLevel:
@@ -29,4 +29,8 @@ class HopperLevel:
 		return()
 
 	def GetLevel(self):
-		return random.randint(10, 100)
+		settings = ReadSettings()
+		if(settings['modules']['grillplat'] == 'prototype'):
+			return random.randint(10, 100)
+		else:
+			return (100)

--- a/installer/debian/other/postinst
+++ b/installer/debian/other/postinst
@@ -73,7 +73,7 @@ service supervisor restart
 cd /usr/local/bin/pifire || exit 1 # Change dir to where the settings.py application is (and common.py)
 python3 settings.py -v @VERSION@
 
-echo " " | sudo tee -a /usr/local/bin/pifire/upgradecheck >/dev/null
+echo " " | sudo tee -a upgradecheck >/dev/null
 
 # Finish
 whiptail --msgbox --backtitle "Install Complete / Reboot Required" --title "Installation Completed" "Congratulations, the installation is complete.  At this time, you should reboot your system to complete the installation.  You should be able to access your application by opening a browser on your PC or other device and using the IP address for this device  Enjoy!" ${r} ${c}

--- a/installer/debian/rpi/postinst
+++ b/installer/debian/rpi/postinst
@@ -76,19 +76,26 @@ cd /usr/local/bin/pifire || exit 1 # Change dir to where the settings.py applica
 
 GRILLPLAT=$(whiptail --title "Select your Grill Platform module to use." --radiolist "Select the Grill Platform module for PiFire to use.  This module initializes GPIOs to control input / output to Grill Platform components like the fan, auger, igniter, etc." 20 78 2 "PIFIRE" "Standard Rasperry Pi <- DEFAULT" ON "PROTOTYPE" "Prototype - Not Platform Dependant (for test only)" OFF 3>&1 1>&2 2>&3)
 
-if [[ $GRILLPLAT == "PIFIRE" ]]; then
-  python3 settings.py -g pifire
+if [[ $GRILLPLAT = "PIFIRE" ]]; then
+    python3 settings.py -g pifire
+    	TRIGGERLEVEL=$(whiptail --title "Set the Trigger Level" --radiolist "Select your relay's trigger level.  (Trigger level High or trigger Low)" 20 78 2 "LOW" "Active Low/Trigger Low" ON "HIGH" "Active High/Trigger High" OFF 3>&1 1>&2 2>&3)
+    	if [[ $TRIGGERLEVEL = "LOW" ]]; then
+    		python3 settings.py -t LOW
+    	fi
+    	if [[ $TRIGGERLEVEL = "HIGH" ]]; then
+    		python3 settings.py -t HIGH
+    	fi
 fi
 
-if [[ $GRILLPLAT == "PROTOTYPE" ]]; then
-  python3 settings.py -g prototype
+if [[ $ADC = "PROTOTYPE" ]]; then
+    python3 settings.py -a prototype
 fi
 
 ADC=$(whiptail --title "Select your ADC module to use." --radiolist "This module gets temperature data from the attached probes such as the RTD Grill Probe, the food probes, etc." 20 78 2 "ADS1115" "Standard ADC <- Default" ON "PROTOTYPE" "Prototype/Simulated (for test only)" OFF 3>&1 1>&2 2>&3)
 
-if [[ $ADC == "ADS1115" ]]; then
-  python3 settings.py -a ads1115
-  sudo -H pip3 install ADS1115
+if [[ $ADC = "ADS1115" ]]; then
+    python3 settings.py -a ads1115
+    	sudo -H pip3 install ADS1115
 fi
 
 if [[ $ADC == "PROTOTYPE" ]]; then
@@ -97,73 +104,87 @@ fi
 
 DISPLAY=$(whiptail --title "Select your Display module to use." --radiolist "Select display type (and input) module for PiFire to use.  Some displays may also have menu button functions indicated by a B appended to the name." 20 78 8 "SSD1306" "OLED Display (128x64) <- DEFAULT" ON "SSD1306B" "OLED Display (128x64) w/Button Input" OFF "ST7789P" "IPS/TFT SPI Display (240x240)P-Pimoroni Libs" OFF "ILI9341" "TFT Color Display (240x320)" OFF "ILI9341B" "TFT Color Display (240x320) w/Buttons" OFF "PROTOTYPE" "Prototype/Console Output (for test only)" OFF "PYGAME" "Prototype/PyGame Desktop Output (for test only)" OFF "PYGAME240320" "Prototype/PyGame (240x320) (for test only)" OFF "PYGAME240320B" "Prototype/PyGame B (240x320) (for test only)" OFF 3>&1 1>&2 2>&3)
 
-if [[ $DISPLAY == "SSD1306" ]]; then
-  python3 settings.py -d ssd1306
-  sudo -H pip3 install luma.oled
+if [[ $DISPLAY = "SSD1306" ]]; then
+    python3 settings.py -d ssd1306
+    	sudo -H pip3 install luma.oled
 fi
 
-if [[ $DISPLAY == "SSD1306B" ]]; then
-  python3 settings.py -d ssd1306b
-  sudo -H pip3 install luma.oled
+if [[ $DISPLAY = "SSD1306B" ]]; then
+    python3 settings.py -d ssd1306b
+    	sudo -H pip3 install luma.oled
+    	BUTTONSLEVEL=$(whiptail --title "Set the Button Level" --radiolist "Select how your button hardware is configured. (HIGH - Pullups, LOW - Pulldowns)" 20 78 2 "LOW" "Pulldowns" OFF "HIGH" "Pullups" ON 3>&1 1>&2 2>&3)
+    	if [[ $BUTTONSLEVEL = "LOW" ]]; then
+    		python3 settings.py -b LOW
+    	fi
+    	if [[ $BUTTONSLEVEL = "HIGH" ]]; then
+    		python3 settings.py -b HIGH
+    	fi
 fi
 
-if [[ $DISPLAY == "ST7789P" ]]; then
-  python3 settings.py -d st7789p
-  echo "dtparam=spi=on" | sudo tee -a /boot/config.txt >/dev/null
-  sudo -H pip3 install st7789
+if [[ $DISPLAY = "ST7789P" ]]; then
+    python3 settings.py -d st7789p
+    	echo "dtparam=spi=on" | sudo tee -a /boot/config.txt > /dev/null
+        sudo -H pip3 install st7789
 fi
 
-if [[ $DISPLAY == "ILI9341" ]]; then
-  python3 settings.py -d ili9341
-  echo "dtparam=spi=on" | sudo tee -a /boot/config.txt >/dev/null
-  sudo -H pip3 install luma.lcd
+if [[ $DISPLAY = "ILI9341" ]]; then
+    python3 settings.py -d ili9341
+    	echo "dtparam=spi=on" | sudo tee -a /boot/config.txt > /dev/null
+        sudo -H pip3 install luma.lcd
 fi
 
-if [[ $DISPLAY == "ILI9341B" ]]; then
-  python3 settings.py -d ili9341b
-  echo "dtparam=spi=on" | sudo tee -a /boot/config.txt >/dev/null
-  sudo -H pip3 install luma.lcd
+if [[ $DISPLAY = "ILI9341B" ]]; then
+    python3 settings.py -d ili9341b
+    	echo "dtparam=spi=on" | sudo tee -a /boot/config.txt > /dev/null
+        sudo -H pip3 install luma.lcd
+    	BUTTONSLEVEL=$(whiptail --title "Set the Button Level" --radiolist "Select how your button hardware is configured. (HIGH - Pullups, LOW - Pulldowns)" 20 78 2 "LOW" "Pulldowns" ON "HIGH" "Pullups" OFF 3>&1 1>&2 2>&3)
+    	if [[ $BUTTONSLEVEL = "LOW" ]]; then
+    		python3 settings.py -b LOW
+    	fi
+    	if [[ $BUTTONSLEVEL = "HIGH" ]]; then
+    		python3 settings.py -b HIGH
+    	fi
 fi
 
-if [[ $DISPLAY == "PROTOTYPE" ]]; then
-  python3 settings.py -d prototype
+if [[ $DISPLAY = "PROTOTYPE" ]]; then
+    python3 settings.py -d prototype
 fi
 
-if [[ $DISPLAY == "PYGAME" ]]; then
-  python3 settings.py -d pygame
-  sudo -H pip3 install pygame
+if [[ $DISPLAY = "PYGAME" ]]; then
+    python3 settings.py -d pygame
+    	sudo -H pip3 install pygame
 fi
 
-if [[ $DISPLAY == "PYGAME240320" ]]; then
-  python3 settings.py -d pygame_240x320
-  sudo -H pip3 install pygame
+if [[ $DISPLAY = "PYGAME240320" ]]; then
+    python3 settings.py -d pygame_240x320
+    	sudo -H pip3 install pygame
 fi
 
-if [[ $DISPLAY == "PYGAME240320B" ]]; then
-  python3 settings.py -d pygame_240x320b
-  sudo -H pip3 install pygame
+if [[ $DISPLAY = "PYGAME240320B" ]]; then
+    python3 settings.py -d pygame_240x320b
+    	sudo -H pip3 install pygame
 fi
 
 DIST=$(whiptail --title "Select your Range module to use." --radiolist "Optional distance sensor for hopper/pellet level reporting.  Default is prototype/none, which is equivalent to no attached sensor." 20 78 3 "PROTOTYPE" "Prototype/None <- DEFAULT" ON "VL53L0X" "Time of Flight Light Range Sensor" OFF "HCSR04" "Ultrasonic Range Sensor" OFF 3>&1 1>&2 2>&3)
 
-if [[ $DIST == "VL53L0X" ]]; then
-  python3 settings.py -r vl53l0x
-  sudo -H pip3 install git+https://github.com/pimoroni/VL53L0X-python.git
+if [[ $DIST = "VL53L0X" ]]; then
+    python3 settings.py -r vl53l0x
+      sudo -H pip3 install git+https://github.com/pimoroni/VL53L0X-python.git
 fi
 
-if [[ $DIST == "HCSR04" ]]; then
-  python3 settings.py -r hcsr04
-  sudo -H pip3 install hcsr04sensor
+if [[ $DIST = "HCSR04" ]]; then
+    python3 settings.py -r hcsr04
+    	sudo -H pip3 install hcsr04sensor
 fi
 
-if [[ $DIST == "PROTOTYPE" ]]; then
-  python3 settings.py -r prototype
+if [[ $DIST = "PROTOTYPE" ]]; then
+    python3 settings.py -r prototype
 fi
 
 ## Update settings server version
 python3 settings.py -v @VERSION@
 
-echo " " | sudo tee -a /usr/local/bin/pifire/upgradecheck >/dev/null
+echo " " | sudo tee -a upgradecheck >/dev/null
 
 # Finished
 whiptail --msgbox --backtitle "Install Complete / Reboot Required" --title "Installation Completed" "Congratulations, the installation is complete.  At this time, you should reboot your system to complete the installation.  You should be able to access your application by opening a browser on your PC or other device and using the IP address for this Pi.  Enjoy!" ${r} ${c}

--- a/installer/debian/rpi/postinst
+++ b/installer/debian/rpi/postinst
@@ -87,8 +87,8 @@ if [[ $GRILLPLAT = "PIFIRE" ]]; then
     	fi
 fi
 
-if [[ $ADC = "PROTOTYPE" ]]; then
-    python3 settings.py -a prototype
+if [[ $GRILLPLAT = "PROTOTYPE" ]]; then
+    python3 settings.py -g prototype
 fi
 
 ADC=$(whiptail --title "Select your ADC module to use." --radiolist "This module gets temperature data from the attached probes such as the RTD Grill Probe, the food probes, etc." 20 78 2 "ADS1115" "Standard ADC <- Default" ON "PROTOTYPE" "Prototype/Simulated (for test only)" OFF 3>&1 1>&2 2>&3)

--- a/installer/debian/rpi/postinst
+++ b/installer/debian/rpi/postinst
@@ -99,10 +99,20 @@ if [[ $ADC = "ADS1115" ]]; then
 fi
 
 if [[ $ADC == "PROTOTYPE" ]]; then
-  python3 settings.py -a prototype
+    python3 settings.py -a prototype
 fi
 
-DISPLAY=$(whiptail --title "Select your Display module to use." --radiolist "Select display type (and input) module for PiFire to use.  Some displays may also have menu button functions indicated by a B appended to the name." 20 78 8 "SSD1306" "OLED Display (128x64) <- DEFAULT" ON "SSD1306B" "OLED Display (128x64) w/Button Input" OFF "ST7789P" "IPS/TFT SPI Display (240x240)P-Pimoroni Libs" OFF "ILI9341" "TFT Color Display (240x320)" OFF "ILI9341B" "TFT Color Display (240x320) w/Buttons" OFF "PROTOTYPE" "Prototype/Console Output (for test only)" OFF "PYGAME" "Prototype/PyGame Desktop Output (for test only)" OFF "PYGAME240320" "Prototype/PyGame (240x320) (for test only)" OFF "PYGAME240320B" "Prototype/PyGame B (240x320) (for test only)" OFF 3>&1 1>&2 2>&3)
+UNITS=$(whiptail --title "Select Temperature Units." --radiolist "Select the temperature units to use globally. (this can be changed later)" 20 78 2 "F" "Fahrenheit <- Default" ON "C" "Celsius" OFF 3>&1 1>&2 2>&3)
+
+if [[ $UNITS = "F" ]];then
+    python3 settings.py -u F
+fi
+
+if [[ $UNITS = "C" ]];then
+    python3 settings.py -u C
+fi
+
+DISPLAY=$(whiptail --title "Select your Display module to use." --radiolist "Select display type (and input) module for PiFire to use.  Some displays may also have menu button functions indicated by a B appended to the name." 20 78 8 "SSD1306" "OLED Display (128x64) <- DEFAULT" ON "SSD1306B" "OLED Display (128x64) w/Button Input" OFF "ST7789P" "IPS/TFT SPI Display (240x240)P-Pimoroni Libs" OFF "ILI9341" "TFT Color Display (240x320)" OFF "ILI9341B" "TFT Color Display (240x320) w/Buttons" OFF "PROTOTYPE" "Prototype/Console Output (for test only)" OFF "PYGAME" "Prototype/PyGame Desktop Output (for test only)" OFF "PYGAME240320" "Prototype/PyGame (240x320) (for test only)" OFF "PYGAME240320B" "Prototype/PyGame B(240x320) (for test only)" OFF "PYGAME64128" "Prototype/PyGame (64x128) (for test only)" OFF 3>&1 1>&2 2>&3)
 
 if [[ $DISPLAY = "SSD1306" ]]; then
     python3 settings.py -d ssd1306
@@ -163,6 +173,11 @@ fi
 if [[ $DISPLAY = "PYGAME240320B" ]]; then
     python3 settings.py -d pygame_240x320b
     	sudo -H pip3 install pygame
+fi
+
+if [[ $DISPLAY = "PYGAME64128" ]];then
+    python3 settings.py -d pygame_64x128
+      sudo -H pip3 install pygame
 fi
 
 DIST=$(whiptail --title "Select your Range module to use." --radiolist "Optional distance sensor for hopper/pellet level reporting.  Default is prototype/none, which is equivalent to no attached sensor." 20 78 3 "PROTOTYPE" "Prototype/None <- DEFAULT" ON "VL53L0X" "Time of Flight Light Range Sensor" OFF "HCSR04" "Ultrasonic Range Sensor" OFF 3>&1 1>&2 2>&3)

--- a/pid.py
+++ b/pid.py
@@ -24,6 +24,7 @@
 # Imported Libraries
 # *****************************************
 import time
+from common import ReadSettings
 
 # *****************************************
 # Class Definition
@@ -37,9 +38,12 @@ class PID:
 		self.D = 0.0
 		self.u = 0
 
+		settings = ReadSettings()
+		self.Center = settings['cycle_data']['center']
+
 		self.Derv = 0.0
 		self.Inter = 0.0
-		self.Inter_max = abs(0.5/self.Ki)
+		self.Inter_max = abs(self.Center/self.Ki)
 
 		self.Last = 150
 
@@ -53,7 +57,7 @@ class PID:
 	def update(self, Current):
 		#P
 		error = Current - self.setPoint
-		self.P = self.Kp*error + 0.5 #P = 1 for PB/2 under setPoint, P = 0 for PB/2 over setPoint
+		self.P = self.Kp*error + self.Center #P = 1 for PB/2 under setPoint, P = 0 for PB/2 over setPoint
 
 		#I
 		dT = time.time() - self.LastUpdate
@@ -87,7 +91,7 @@ class PID:
 
 	def setGains(self, PB, Ti, Td):
 		self.CalculateGains(PB,Ti,Td)
-		self.Inter_max = abs(0.5/self.Ki)
+		self.Inter_max = abs(self.Center/self.Ki)
 
 	def getK(self):
 		return self.Kp, self.Ki, self.Kd

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -430,6 +430,13 @@
                         </div>
                         <input id="u_max" type="number" min="0.1" step="0.01" class="form-control" placeholder="{{ settings['cycle_data']['u_max'] }}" value="{{ settings['cycle_data']['u_max'] }}" name="u_max">
                     </div>
+                    <div class="input-group mb-3">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text" data-toggle="tooltip" title="Center Ratio [Default=0.5]">
+                                <i class="far fa-clock"></i>&nbsp; Center Ratio</span>
+                        </div>
+                        <input id="center" type="number" min="0.1" step="0.01" class="form-control" placeholder="{{ settings['cycle_data']['center'] }}" value="{{ settings['cycle_data']['center'] }}" name="center">
+                    </div>
                     <span class="badge badge-warning">NOTE:</span>
                     <i class="small"> If you are in hold mode currently, you will need to change to another mode and back into hold mode for this to take effect. More information on the PID control settings can be found <a href="http://engineeredmusings.com/pismoker/" target="blank">here.</a>
                     </i>


### PR DESCRIPTION
Add Backup/Restore functions to SocketIO for Android Client. Add PID center ratio option for more control of auger time during hold mode. Change prototype distance to only show random if grillplat is also set to prototype. Add units change function to Socket IO. Updated rpi postinst with new install script and include unit change option and new pygame display.