### PR TITLE
enabled support for probe mapping and max31865

### DIFF
--- a/adc_ads1115.py
+++ b/adc_ads1115.py
@@ -30,7 +30,7 @@ class ReadADC:
 		self.probe_02_profile = probe_02_profile
 
 	def adctotemp(self, adc_value, probe_profile):
-		if(adc_value > 0) and (adc_value < (probe_profile['Vs'] * 1000)):
+		if(adc_value > 0) and (adc_value < (probe_profile['Vs'] * 1000) * 0.99):
 			# Voltage at the divider (i.e. input to the ADC)
 			Vo = (adc_value / 1000) # mV to V of ADC (at the divider)
 

--- a/common.py
+++ b/common.py
@@ -44,7 +44,9 @@ def DefaultSettings():
 
 	settings['probe_settings'] = {
 		'probe_profiles' :  DefaultProbeProfiles(),
-		'probes_enabled' : [1,1,1]
+		'probes_enabled' : [1,1,1],
+		# probe sources can be ADC0-3 or max31865
+		'probe_sources'  : ['ADC0', 'ADC1', 'ADC2']
 	}
 
 	settings['globals'] = {

--- a/control.py
+++ b/control.py
@@ -24,6 +24,7 @@ from pushbullet import Pushbullet  # Pushbullet Import
 
 import pid as PID  # Library for calculating PID setpoints
 from common import *  # Common Library for WebUI and Control Program
+
 from temp_queue import TempQueue
 
 # Read Settings to Get Modules Configuration 
@@ -69,10 +70,36 @@ elif settings['modules']['dist'] == 'hcsr04':
 else:
     from distance_prototype import HopperLevel  # Simulated Library for reading the HopperLevel
 
+for probe_source in settings['probe_settings']['probe_sources']:
+    # if any of the probes uses max31865 then load the library
+    if 'max31865' in probe_source:
+        from probe_max31865 import probe_max31865_read
+        break
 
 # *****************************************
 # Function Definitions
 # *****************************************
+def ReadProbes(settings, adc_device, units):
+    adc_data = adc_device.ReadAllPorts()
+
+    prob_data = {}
+
+    probe_ids = ['Grill', 'Probe1', 'Probe2']
+    adc_properties = ['Temp', 'Tr']
+    adc_probe_indices = ['Grill', 'Probe1', 'Probe2']
+    for idx, probe_source in enumerate(settings['probe_settings']['probe_sources']):
+        if 'ADC' in probe_source and len(probe_source) > 3:
+            # map ADC proves to the output probes. i.e ADC0 is adc_probe_indices[0] => 'Grill' so if this is defined
+            # for first source map Grill to Grill. If ADC1 in first source map it to Probe1
+            source_index = int(probe_source[3:])
+            for p in adc_properties:
+                prob_data[probe_ids[idx] + p] = adc_data[adc_probe_indices[source_index] + p]
+        elif 'max31865' in probe_source:
+            temperature, resistance = probe_max31865_read(units=units)
+            prob_data[probe_ids[idx] + adc_properties[0]] = temperature
+            prob_data[probe_ids[idx] + adc_properties[1]] = resistance
+
+    return prob_data
 
 
 def GetStatus(grill_platform, control, settings, pelletdb):
@@ -183,8 +210,7 @@ def WorkCycle(mode, grill_platform, adc_device, display_device, dist_device):
                            settings['probe_settings']['probe_profiles'][probe1type],
                            settings['probe_settings']['probe_profiles'][probe2type])
 
-    adc_data = {}
-    adc_data = adc_device.ReadAllPorts()
+    adc_data = ReadProbes(settings, adc_device, units)
 
     AvgGT.enqueue(adc_data['GrillTemp'])
     AvgP1.enqueue(adc_data['Probe1Temp'])
@@ -361,8 +387,7 @@ def WorkCycle(mode, grill_platform, adc_device, display_device, dist_device):
                                    settings['probe_settings']['probe_profiles'][probe2type])
 
         # Get temperatures from all probes
-        adc_data = {}
-        adc_data = adc_device.ReadAllPorts()
+        adc_data = ReadProbes(settings, adc_device, units)
 
         # Test temperature data returned for errors (+/- 20% Temp Variance), and average the data since last reading
         AvgGT.enqueue(adc_data['GrillTemp'])
@@ -543,8 +568,7 @@ def Monitor(grill_platform, adc_device, display_device, dist_device):
                            settings['probe_settings']['probe_profiles'][probe1type],
                            settings['probe_settings']['probe_profiles'][probe2type])
 
-    adc_data = {}
-    adc_data = adc_device.ReadAllPorts()
+    adc_data = ReadProbes(settings, adc_device, units)
 
     AvgGT.enqueue(adc_data['GrillTemp'])
     AvgP1.enqueue(adc_data['Probe1Temp'])
@@ -632,8 +656,7 @@ def Monitor(grill_platform, adc_device, display_device, dist_device):
                                    settings['probe_settings']['probe_profiles'][probe1type],
                                    settings['probe_settings']['probe_profiles'][probe2type])
 
-        adc_data = {}
-        adc_data = adc_device.ReadAllPorts()
+        adc_data = ReadProbes(settings, adc_device, units)
 
         # Test temperature data returned for errors (+/- 20% Temp Variance), and average the data since last reading
         AvgGT.enqueue(adc_data['GrillTemp'])
@@ -720,8 +743,7 @@ def Monitor(grill_platform, adc_device, display_device, dist_device):
                            settings['probe_settings']['probe_profiles'][probe1type],
                            settings['probe_settings']['probe_profiles'][probe2type])
 
-    adc_data = {}
-    adc_data = adc_device.ReadAllPorts()
+    adc_data = ReadProbes(settings, adc_device, units)
 
     AvgGT.enqueue(adc_data['GrillTemp'])
     AvgP1.enqueue(adc_data['Probe1Temp'])
@@ -809,8 +831,7 @@ def Monitor(grill_platform, adc_device, display_device, dist_device):
                                    settings['probe_settings']['probe_profiles'][probe1type],
                                    settings['probe_settings']['probe_profiles'][probe2type])
 
-        adc_data = {}
-        adc_data = adc_device.ReadAllPorts()
+        adc_data = ReadProbes(settings, adc_device, units)
 
         # Test temperature data returned for errors (+/- 20% Temp Variance), and average the data since last reading
         AvgGT.enqueue(adc_data['GrillTemp'])
@@ -903,8 +924,7 @@ def Manual_Mode(grill_platform, adc_device, display_device, dist_device):
                            settings['probe_settings']['probe_profiles'][probe1type],
                            settings['probe_settings']['probe_profiles'][probe2type])
 
-    adc_data = {}
-    adc_data = adc_device.ReadAllPorts()
+    adc_data = ReadProbes(settings, adc_device, units)
 
     AvgGT.enqueue(adc_data['GrillTemp'])
     AvgP1.enqueue(adc_data['Probe1Temp'])
@@ -1667,5 +1687,3 @@ while True:
 # ===================
 # End of Main Loop
 # ===================
-
-

--- a/probe_max31865.py
+++ b/probe_max31865.py
@@ -1,0 +1,160 @@
+import logging.config
+import math
+import time
+
+import spidev
+
+# Start logging
+logger = logging.getLogger(__name__)
+
+# Register and other constant values:
+
+_RTD_A = 3.9083e-3
+_RTD_B = -5.775e-7
+
+
+# Datasheet https://datasheets.maximintegrated.com/en/ds/MAX31865.pdf
+class MAX31865:
+
+    def __init__(self, cs, rtd_nominal=100,
+                 ref_resistor=430.0,
+                 wires=2):
+
+        self.cs = cs
+        self.wires = wires
+
+        # RTD Constants
+        self.rtd_nominal = rtd_nominal
+        self.ref_resistor = ref_resistor
+        self.A = 3.90830e-3
+        self.B = -5.775e-7
+
+        # Setup SPI
+        self.spi = spidev.SpiDev()
+        self.spi.open(0, 1)
+        self.spi.max_speed_hz = 7629
+        self.spi.mode = 0b01
+
+        self.config()
+
+    def config(self):
+        # Config
+        # V_Bias (1=on)
+        # Conversion Mode (1 = Auto)
+        # 1-Shot
+        # 3-Wire (0 = Off)
+        # Fault Detection (2 Bits)
+        # Fault Detection
+        # Fault Status
+        # 50/60Hz (0 = 60 Hz)
+        if self.wires == 3:
+            config = 0b11010010  # 0xD2
+        else:
+            config = 0b11000010  # 0xC2
+
+        self.spi.xfer2([0x80, config])
+        time.sleep(0.25)
+        t = self.temperature
+
+    def read_rtd(self):
+        msb = self.spi.xfer2([0x01, 0x00])[1]
+        lsb = self.spi.xfer2([0x02, 0x00])[1]
+
+        # Check fault
+        if lsb & 0b00000001:
+            logger.debug('Fault Detected SPI %i', self.cs)
+            self.get_fault()
+
+        adc = ((msb << 8) + lsb) >> 1  # Shift MSB up 8 bits, add to LSB, remove fault bit (last bit)
+        return adc
+
+    @property
+    def resistance(self):
+        """Read the resistance of the RTD and return its value in Ohms."""
+        resistance = self.read_rtd()
+        resistance /= 32768
+        resistance *= self.ref_resistor
+        return resistance
+
+    @property
+    def fahrenheit(self):
+        return (self.celsius - 32) / 1.8
+
+    @property
+    def fahrenheit_resistance(self):
+        celsius, resistance = self.celsius_resistance
+        return (celsius - 32) / 1.8, resistance
+
+    @property
+    def temperature(self):
+        return self.celsius
+
+    @property
+    def celsius(self):
+        return self.celsius_resistance[0]
+
+    @property
+    def celsius_resistance(self):
+        """Read the temperature of the sensor and return its value in degrees
+        Celsius.
+        """
+        # This math originates from:
+        # http://www.analog.com/media/en/technical-documentation/application-notes/AN709_0.pdf
+        # To match the naming from the app note we tell lint to ignore the Z1-4
+        # naming.
+        # pylint: disable=invalid-name
+        raw_reading = self.resistance
+        Z1 = -_RTD_A
+        Z2 = _RTD_A * _RTD_A - (4 * _RTD_B)
+        Z3 = (4 * _RTD_B) / self.rtd_nominal
+        Z4 = 2 * _RTD_B
+        temp = Z2 + (Z3 * raw_reading)
+        temp = (math.sqrt(temp) + Z1) / Z4
+        if temp >= 0:
+            return temp, temp
+
+        # For the following math to work, nominal RTD resistance must be normalized to 100 ohms
+        raw_reading /= self.rtd_nominal
+        raw_reading *= 100
+
+        rpoly = raw_reading
+        temp = -242.02
+        temp += 2.2228 * rpoly
+        rpoly *= raw_reading  # square
+        temp += 2.5859e-3 * rpoly
+        rpoly *= raw_reading  # ^3
+        temp -= 4.8260e-6 * rpoly
+        rpoly *= raw_reading  # ^4
+        temp -= 2.8183e-8 * rpoly
+        rpoly *= raw_reading  # ^5
+        temp += 1.5243e-10 * rpoly
+        return temp, raw_reading
+
+    def get_fault(self):
+        fault = self.spi.xfer2([0x07, 0x00])[1]
+
+        if fault & 0b10000000:
+            logger.debug('Fault SPI %i: RTD High Threshold', self.cs)
+        if fault & 0b01000000:
+            logger.debug('Fault SPI %i: RTD Low Threshold', self.cs)
+        if fault & 0b00100000:
+            logger.debug('Fault SPI %i: REFIN- > 0.85 x V_BIAS', self.cs)
+        if fault & 0b0001000:
+            logger.debug('Fault SPI %i: REFIN- < 0.85 x V_BIAS (FORCE- Open)', self.cs)
+        if fault & 0b00001000:
+            logger.debug('Fault SPI %i: RTDIN- < 0.85 x V_BIAS (FORCE- Open)', self.cs)
+        if fault & 0b00000100:
+            logger.debug('Fault SPI %i: Overvoltage/undervoltage fault', self.cs)
+
+    def close(self):
+        self.spi.close()
+
+
+max_probe = MAX31865(1, 100, 430.0, True)
+
+
+def probe_max31865_read(units='F'):
+    if units == 'F':
+        return max_probe.fahrenheit_resistance
+    else:
+        return max_probe.celsius_resistance


### PR DESCRIPTION
This adds support for probe mapping and a new type max31865. While I didnt touch any of the control code this simply allows the user to configure the systems 3 types: Grill, Probe1, Probe2. The default mapping is:

```
System                   Source
------------------------
Grill        <-      ADC0
Probe1       <-      ADC1
Probe2       <-      ADC2
-------------------------
```

alternative it can be configured like switching the ADC index between Grill and Probe2
```
System                   Source
------------------------
Grill         <-      ADC2
Probe1        <-      ADC1
Probe2        <-      ADC0
-------------------------
```
however the reason for adding the mapping is to allow other sources
```
System                   Source
------------------------
Grill        <-      max31865
Probe1       <-      ADC1
Probe2       <-      ADC2
-------------------------
```
The max31865 driver is set to spi device 2.

If this is merged it may be worth simplifying the ADC driver to just use ADC0-3 when reporting the values.

settings looks like this if max31865 is used for grill

```json
  "probe_settings": {
    ....
    "probes_enabled": [
      1,
      1,
      1
    ],
    "probe_sources": ["max31865","ADC1","ADC2"]
  },
...
```