### PR TITLE
Bugfix Updater error message

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -96,7 +96,7 @@ def get_available_updates(branch=''):
 			result['message'] = 'ERROR Getting Revision List: ' + revlist.stderr.replace('\n', ' ') + revlist.stdout.replace('\n', ' ')
 	else:
 		result['success'] = False 
-		result['message'] = 'ERROR Getting Remote or Branch: ' + error_msg1 + ' ' + error_msg2
+		result['message'] = 'ERROR Getting Remote or Branch: ' + error_msg1.replace('\n', ' ') + ' ' + error_msg2.replace('\n', ' ')
 	return(result)
 
 def do_update():


### PR DESCRIPTION
Bugfix Updater error message by removing newlines. During some testing I found that if a git branch is not found the events page will 500 error with UndefinedError: list object has no element 2. This was due to newlines being added to events.log from the updater result['message']

![Screenshot from 2022-02-16 17-28-00](https://user-images.githubusercontent.com/313328/154407296-de038d24-b92e-4b81-b216-f261d216c8a9.png)
