### PR TITLE
Added auto power off feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -836,6 +836,12 @@ def settingspage(action=None):
 			if(response['startup_timer'] != ''):
 				settings['globals']['startup_timer'] = int(response['startup_timer'])
 
+		if('auto_power_off' in response):
+			if(response['auto_power_off'] == 'on'):
+				settings['globals']['auto_power_off'] = True
+		else:
+			settings['globals']['auto_power_off'] = False
+
 		event['type'] = 'updated'
 		event['text'] = 'Successfully updated startup/shutdown settings.'
 

--- a/common.py
+++ b/common.py
@@ -58,6 +58,7 @@ def DefaultSettings():
 		'buttonslevel' : 'HIGH',
 		'shutdown_timer' : 60,
 		'startup_timer' : 240,
+		'auto_power_off' : False,
 		'four_probes' : False,
 		'units' : 'F',
 		'augerrate' : 0.3,  # (grams per second) default auger load rate is 10 grams / 30 seconds

--- a/control.py
+++ b/control.py
@@ -1722,6 +1722,9 @@ while True:
                 control['mode'] = 'Stop'  # Set mode to Stop
                 control['updated'] = True
                 WriteControl(control)
+                if settings['globals']['auto_power_off']:
+                    WriteLog('Shutdown mode ended powering off grill')
+                    os.system("sleep 3 && sudo shutdown -h now &")
         # e. Monitor (monitor the OEM controller)
         elif control['mode'] == 'Monitor':
             control['status'] = 'monitor'  # Set status to monitor

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -589,6 +589,7 @@
                             </h5>
                         </div>
                         <div class="card-body">
+                            <h5>Timer Settings</h5>
                             <div class="input-group mb-3">
                                 <div class="input-group-prepend">
                                     <span class="input-group-text" data-toggle="tooltip" title="Shutdown timer (seconds) [Default=60]">
@@ -609,6 +610,17 @@
                             </div>
                             <span class="badge badge-warning">NOTE:</span>
                             <i class="small"> Amount of time for startup before transitioning to smoke or attempting a reignite</i>
+                            <br>
+                            <br>
+                            <h5>Power Off Settings</h5>
+                            <span class="badge badge-warning">NOTE:</span>
+                            <i class="small"> When enabled the Raspberry Pi will auto power off after the Grill Shutdown Mode has ended</i>
+                            <br>
+                            <br>
+                            <div class="custom-control custom-switch">
+                                <input type="checkbox" class="custom-control-input" id="auto_power_off" name="auto_power_off" {% if settings['globals']['auto_power_off'] == True %}checked{% endif %}>
+                                <label class="custom-control-label" for="auto_power_off">Auto Power Off</label>
+                            </div>
                             <br>
                         </div>
                         <!-- End of card body -->


### PR DESCRIPTION
Added auto power off feature. When enabled the raspberry pi will be shutdown/powered off when the grill shutdown mode has ended.

I am lazy and always forget to grab my phone or pc and do a graceful shutdown after cooking and usually just end up unplugging the grill with the pi running. While it is probably not a huge issue it would suck if the something went wrong and I had to pull the pi. So to make life easier I added an option to gracefully shutdown the pi after the grill shutdown mode has ended. Now I do not feel so bad when I just walk up and unplug it. 