### PR TITLE
Add function to download server logs

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -92,6 +92,12 @@
 		</div>
 		<div class="card-body">
 			<form name="input" action="/admin/setting" method="POST">
+			<!-- Download Logs -->
+				<button type="submit" class="btn btn-outline-success btn-block shadow" name="download_logs" value="true">
+					Download Server Logs
+				</button>
+				<br>
+
 			<!-- Backup Settings -->
 				<button type="submit" class="btn btn-outline-success btn-block shadow" name="backupsettings" value="true">
 					Backup Settings


### PR DESCRIPTION
Add function to zip and download server logs directory for easier user troubleshooting. Install was made user friendly so might as well make troubleshooting easier this way a user does not need to ssh in and get the files manually when requested etc. 