### PR TITLE
Update default PWM frequency to 25 kHz

### DIFF
--- a/common/common.py
+++ b/common/common.py
@@ -176,7 +176,7 @@ def default_settings():
 	settings['pwm'] = {
 		'pwm_control': False,
 		'update_time' : 10,
-		'frequency' : 30, 		# PWM Fan Frequency. This may vary with different fans
+		'frequency' : 25000,    # PWM Fan Frequency. Intel 4-wire PWM spec specifies 25 kHz
 		'min_duty_cycle' : 20, 	# This is the minimum duty cycle that can be set. Some fans stall below a certain speed
 		'max_duty_cycle' : 100, # This is the maximum duty cycle that can be set. Can limit fans that are overpowered
 		'temp_range_list' : [3, 7, 10, 15],  # Temp Bands for Each Profile


### PR DESCRIPTION
Section 2.1.4 of the 2005 Intel standard for 4-pin PWM fans specifies 25 kHz as the PWM frequency.

https://www.intel.com/content/dam/support/us/en/documents/intel-nuc/intel-4wire-pwm-fans-specs.pdf

Many PWM fans will not operate at the previous default of 30 Hz, and the new hardware PWM implementation can easily support 25 kHz, so updating the PiFire default to match the published specifications for PC PWM fans seems prudent.