### PR TITLE
Bugfix Apprise locations should be an Array not an Object

### DIFF
--- a/common/common.py
+++ b/common/common.py
@@ -337,7 +337,7 @@ def default_notify_services():
 
 	services['apprise'] = {
 		'enabled': False,
-		'locations': {} 		# list of locations
+		'locations': [] 		# list of locations
 	}
 
 	services['ifttt'] = {


### PR DESCRIPTION
This is still creating a lot of errors in the old app version. It is fixed in dev branch now but it would be good to fix it in main until dev is released. 