### PR TITLE
Toast div was blocking menu nav bar when page was loaded.  

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -210,7 +210,7 @@
 		{% block toasts %}
 			<!-- Toast Container (positioned at top-right) -->
 			<div class="position-fixed" style="top: 20px; right: 20px; z-index: 1050">
-				<div id="notifyToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-delay="5000">
+				<div id="notifyToast" class="toast hide" role="alert" aria-live="assertive" aria-atomic="true" data-delay="5000">
 					<div class="toast-header">
 						<img src="{{ url_for('static', filename='img/launcher-icon-1x.png') }}" class="rounded mr-2" style="width: 24px;"alt="Bloop">
 						<strong class="mr-auto" id="toastTitle">Toast!</strong>


### PR DESCRIPTION
The toast div was missing the hide class.  This made it block the nav bar when the page was loaded.  Adding the hide class has no effect on the displaying and autohiding of toast messages.