### PR TITLE
Attribution fix in post-update-message

### DIFF
--- a/updater/post-update-message.html
+++ b/updater/post-update-message.html
@@ -128,7 +128,7 @@
                     are not connected.
                  </li>
                  <li>
-                    Github user @whightmanjr contributed a fix for the PID controllers to prevent divide by zero errors from crashing the control process. 
+                    Github user @markalston contributed a fix for the PID controllers to prevent divide by zero errors from crashing the control process. 
                  </li>
              </ul>
              


### PR DESCRIPTION
Nebhead, just a quick correction on attribution for the divide by zero fixes, unless @whightmanjr also submitted the same fix, in that case ignore this pull request.