### PR TITLE
Added new clamping pid controller.

### DIFF
--- a/controller/controllers.json
+++ b/controller/controllers.json
@@ -233,6 +233,58 @@
                 }
             ]
         },
+		"pid_clamping" : {
+            "friendly_name" : "PID w/ Integrator Clamping",
+            "module_name" : "pid_clamping",
+            "image" : "pid.png",
+            "description" : "The original PiFire PID modified to both calculate the derivative portion in the classic de/dt method instead of the dT/dt method and with integral anti-windup protection achieved with a clamping method.",
+            "author" : "Mark Alston",
+            "link" : "https://github.com/markalston/PiFire", 
+            "contributors" : ["Ben Parmeter", "James Weber", "Mark Alston"],
+            "attributions" : [],
+            "recommendations" : {
+                "cycle" : { 
+                    "cycle_time" : 10,
+                    "cycle_ratio_min" : 0.05,
+                    "cycle_ratio_max" : 0.99
+                }
+            },
+            "config" : [
+                {
+                    "option_name" : "PB",
+                    "option_friendly_name" : "Proportional Band(PB)", 
+                    "option_description" : "The proportional band is the total range of the controlled output that can be produced within the controller’s 0% and 100% limits.   Within the PB the command output is between 1.0 and 0.  Outside the band the command output is 1 or -1 (fully on or off). Increase this if you are overshooting setpoint.[Default=30.0]",
+                    "option_type" : "float",
+                    "option_default" : 30.0,
+                    "option_min" : null,
+                    "option_max" : null, 
+                    "option_step" : 0.1,
+                    "hidden" : false
+                },
+                {
+                    "option_name" : "Td",
+                    "option_friendly_name" : "Derivative Time Constant (Td)", 
+                    "option_description" : "Time constant that determines how quickly the system reponds to changes in error rate. Higher Td makes the controller more responsive to the Error Rate of Change. Td basically acts as a damper on the system. Be cautious with this setting and start low and increase slowly. It might not even be needed and can easily drive a system into instability. [Default=20.0]",
+                    "option_type" : "float",
+                    "option_default" : 20.0,
+                    "option_min" : null,
+                    "option_max" : null,
+                    "option_step" : 0.1,  
+                    "hidden" : false
+                },
+                {
+                    "option_name" : "Ti",
+                    "option_friendly_name" : "Integral Time Constant (Ti)", 
+                    "option_description" : "Time constant that determines how quickly we respond to accumulated error. Higher Ti makes the controller less responsive to accumulated error over time. Increase this if you cannot reach setpoint. [Default=120.0]",
+                    "option_type" : "float",
+                    "option_default" : 120.0,
+                    "option_min" : null,
+                    "option_max" : null, 
+                    "option_step" : 0.1,
+                    "hidden" : false
+                }
+            ]
+        },
         "fuzzy" : {
             "friendly_name" : "Fuzzy Logic Controller",
             "module_name" : "fuzzy",

--- a/controller/pid_clamping.py
+++ b/controller/pid_clamping.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+'''
+*****************************************
+ PiFire PID Controller
+*****************************************
+
+ Description: This object will be used to calculate PID for maintaining
+ temperature in the grill.  This controller adds basic clamping to prevent windup.
+ When the output is saturated (either below 0 or above 1) then we do not increase the integral output.
+ https://info.erdosmiller.com/blog/pid-anti-windup-techniques
+
+ This controller was originally developed by GitHub user DBorello as part of his excellent
+ PiSmoker project: https://github.com/DBorello/PiSmoker and modified by GitHub user markalston.
+
+ PID controller based on proportional band in standard PID form https://en.wikipedia.org/wiki/PID_controller#Ideal_versus_standard_PID_form
+   u   = Kp (e(t)+ 1/Ti INT + Td de/dt) = controller output
+  PB   = Proportional Band
+  Kp   = Proportional Gain = 1/PB
+  Ti   = Integration Time constant
+  Td   = Derivative Time Constant
+  de   = Change in Error
+  dt   = Change in Time
+  INT  = Historic cumulative value of errors
+  e(t) = Current Error = Set Point - Current Temp
+
+  
+  Configuration Defaults: 
+  "config": {
+      "PB": 30.0,
+      "Td": 20.0,
+      "Ti": 120.0
+   }
+
+*****************************************
+'''
+
+'''
+Imported Libraries
+'''
+import time
+import logging
+from common import create_logger
+from controller.base import ControllerBase 
+log_level = logging.DEBUG
+eventLogger = create_logger('events', filename='/tmp/events.log', messageformat='%(asctime)s [%(levelname)s] %(message)s', level=log_level)
+
+'''
+Class Definition
+'''
+class Controller(ControllerBase):
+	def __init__(self, config, units, cycle_data):
+		super().__init__(config, units, cycle_data)
+
+		self._calculate_gains(config['PB'], config['Ti'], config['Td'])
+
+		self.p = 0.0
+		self.i = 0.0
+		self.d = 0.0
+		self.u = 0
+
+		self.last_update = time.time()
+		self.error = 0.0
+		self.error_last = 0.0
+		self.set_point = 0
+
+		self.derv = 0.0
+		self.inter = 0.0
+
+		self.set_target(0.0)
+
+	def _calculate_gains(self, pb, ti, td):
+		if pb == 0:
+			self.kp = 0
+		else:
+			self.kp = -1 / pb
+		if ti == 0:
+			self.ki = 0
+		else:
+			self.ki = self.kp / ti
+		self.kd = self.kp * td
+		eventLogger.debug('kp: ' + str(self.kp) + ', ki: ' + str(self.ki) + ', kd: ' + str(self.kd))
+
+	def update(self, current):
+		# dt
+		dt = time.time() - self.last_update
+
+		# P
+		error = current - self.set_point
+		self.p = self.kp * error
+
+		# I
+		self.inter += error * dt
+		self.i = self.ki * self.inter
+
+		# D
+		self.derv = (error - self.error_last) / dt
+		self.d = self.kd * self.derv
+
+		# PID
+		self.u = self.p + self.i + self.d
+
+		# Clamping anti-windup method. 
+		# Stops integration when the sum of the block components exceeds the output limits 
+		# and the integrator output and block input have the same sign. 
+		# Resumes integration when either the sum of the block components exceeds the output limits 
+		# and the integrator output and block input have opposite sign or the sum no longer exceeds the output limits.
+		# 
+		# Implemented via reversing the addition to self.inter above if we are clamping.		
+		if not ((abs(self.u) >= 1) and (self.i * self.u > 0)):
+			eventLogger.debug('Not clamping integrator.')
+		else:
+			eventLogger.debug('clamping integrator.')
+			self.inter -= error * dt
+		
+		eventLogger.debug('PID Update... error: ' + str(error) + ', p: ' + str(self.p) + ', i: ' + str(self.i) + ', d: ' + str(self.d))
+
+		# Update for next cycle
+		self.error_last = error
+		self.last_update = time.time()
+
+		return self.u
+
+	def set_target(self, set_point):
+		self.set_point = set_point
+		self.error = 0.0
+		self.inter = 0.0
+		self.derv = 0.0
+		self.last_update = time.time()
+
+	def set_gains(self, pb, ti, td):
+		self._calculate_gains(pb,ti,td)
+
+
+	def get_k(self):
+		return self.kp, self.ki, self.kd
+	
+	def supported_functions(self):
+		function_list = [
+			'update', 
+	        'set_target', 
+	        'get_config', 
+			'set_gains', 
+			'get_k'
+        ]
+		return function_list

--- a/updater/post-update-message.html
+++ b/updater/post-update-message.html
@@ -128,7 +128,7 @@
                     are not connected.
                  </li>
                  <li>
-                    Github user @whightmanjr contributed a fix for the PID controllers to prevent divide by zero errors from crashing the control process. 
+                    Github user @markalston contributed a fix for the PID controllers to prevent divide by zero errors from crashing the control process. 
                  </li>
              </ul>
              


### PR DESCRIPTION
It turns out that the pid controllers currently implemented in piFire do not correctly calculate the derivative portion.

The current pid's are calculating the change in temp instead of the change in error for the derivative.  This basically results in a duplicate of the Proportional part of the PID but with a lower constant applied.    I believe that this is the reason that many of the pid controllers are needing to use various centering and other methods to avoid overshoot and other pid issues.

This pid controller correctly calculates the D part of the PID and additionally implements the clamping anti-windup method.

I have tested this pid controller on my pit and it is holding temps within 4 degrees of the setpoint without any real tuning and just using my guessed upon defaults.   There is no initial overshoot and the pit settles into a nice even oscillation around the setpoint very quickly.

I'd like to get this out for others to try and believe that this method will turn out to be both superior and simpler but I also believe that we need to leave all the existing pid controllers intact as many folks have probably tuned their pits around the miscalculated D and may have issues with a forced swap.

Thanks.