### PR TITLE
Couple Bugfixes for Socket IO

### DIFF
--- a/mobile/socket_io.py
+++ b/mobile/socket_io.py
@@ -189,7 +189,7 @@ def _get_dash_data(settings, pelletdb):
         'primeAmount': status['prime_amount'],
         'tempUnits': settings['globals']['units'],
         'hasDcFan': settings['platform']['dc_fan'],
-        'hasDistanceSensor': settings['modules']['distance'] != 'none',
+        'hasDistanceSensor': settings['modules']['dist'] != 'none',
         'startupCheck': settings['safety']['startup_check'],
         'allowManualOutputs': settings['safety']['allow_manual_changes'],
         'timer': {


### PR DESCRIPTION
Bugfix check_control_status was causing false error when checking every second in loop, bump checking to 30 seconds, change the message to match dash or it can cause a duplicate error. Bugfix units_action not returning settings data. Add hasDistanceSensor for dash_data (needed by app)