### PR TITLE
Include measured temperature in grill errors

### DIFF
--- a/control.py
+++ b/control.py
@@ -469,14 +469,15 @@ def _work_cycle(mode, grill_platform, probe_complex, display_device, dist_device
 		write_control(control, direct_write=True, origin='control')
 	# Check if the temperature of the grill dropped below the startuptemp
 	elif mode in ('Smoke', 'Hold'):
-		if control['safety']['afterstarttemp'] < control['safety']['startuptemp']:
+		error_grill_temp = control['safety']['afterstarttemp']
+		if error_grill_temp < control['safety']['startuptemp']:
 			if control['safety']['reigniteretries'] == 0:
 				status = 'Inactive'
 				display_device.display_text('ERROR')
 				control['mode'] = 'Error'
 				control['updated'] = True
 				write_control(control, direct_write=True, origin='control')
-				send_notifications("Grill_Error_02")
+				send_notifications("Grill_Error_02", error_grill_temp=error_grill_temp)
 			else:
 				control['safety']['reigniteretries'] -= 1
 				control['safety']['reignitelaststate'] = mode
@@ -485,7 +486,7 @@ def _work_cycle(mode, grill_platform, probe_complex, display_device, dist_device
 				control['mode'] = 'Reignite'
 				control['updated'] = True
 				write_control(control, direct_write=True, origin='control')
-				send_notifications("Grill_Error_03")
+				send_notifications("Grill_Error_03", error_grill_temp=error_grill_temp)
 
 	# Apply Smart Start Settings if Enabled 
 	startup_timer = settings['startup']['duration']
@@ -848,7 +849,7 @@ def _work_cycle(mode, grill_platform, probe_complex, display_device, dist_device
 					control['mode'] = 'Error'
 					control['updated'] = True
 					write_control(control, direct_write=True, origin='control')
-					send_notifications("Grill_Error_02")
+					send_notifications("Grill_Error_02", error_grill_temp=ptemp)
 					break
 				else:
 					control['safety']['reigniteretries'] -= 1
@@ -857,7 +858,7 @@ def _work_cycle(mode, grill_platform, probe_complex, display_device, dist_device
 					control['mode'] = 'Reignite'
 					control['updated'] = True
 					write_control(control, direct_write=True, origin='control')
-					send_notifications("Grill_Error_03")
+					send_notifications("Grill_Error_03", error_grill_temp=ptemp)
 					break
 
 
@@ -1050,7 +1051,7 @@ def _work_cycle(mode, grill_platform, probe_complex, display_device, dist_device
 			control['mode'] = 'Error'
 			control['updated'] = True
 			write_control(control, direct_write=True, origin='control')
-			send_notifications("Grill_Error_01")
+			send_notifications("Grill_Error_01", error_grill_temp=ptemp)
 			break
 
 		# End of Loop Recipe Check

--- a/notify/notifications.py
+++ b/notify/notifications.py
@@ -149,13 +149,14 @@ def check_notify(settings, control, in_data=None, pelletdb=None, grill_platform=
 
 	return control
 
-def send_notifications(notify_event, label='Probe', target=0):
+def send_notifications(notify_event, label='Probe', target=0, error_grill_temp=0):
 	"""
 	Build and send notification based on notify_event and write to log.
 
 	:param notify_event: String Event
 	:param label: Label
 	:param target: Target Value
+	:param error_grill_temp: Measured grill temperature for safety error notifications
 	"""
 	settings = read_settings()
 	control = read_control()
@@ -201,26 +202,38 @@ def send_notifications(notify_event, label='Probe', target=0):
 		eventLogger.info(body_message)
 	elif "Grill_Error_01" in notify_event:
 		title_message = "Grill Error!"
-		body_message = "Grill exceded maximum temperature limit of " + str(
-			settings['safety']['maxtemp']) + unit + "! Shutting down. " + str(now)
+		body_message = "Grill temperature " + str(error_grill_temp) + unit + \
+			" exceeded maximum temperature limit of " + str(settings['safety']['maxtemp']) + unit + \
+			"! Shutting down. " + str(now)
 		channel = 'pifire_error_alerts'
-		query_args = {"value1": str(settings['safety']['maxtemp'])}
+		query_args = {
+			"value1": str(settings['safety']['maxtemp']),
+			"value2": str(error_grill_temp),
+		}
 		eventLogger.info(body_message)
 	elif "Grill_Error_02" in notify_event:
 		control = read_control()
 		title_message = "Grill Error!"
-		body_message = "Grill temperature dropped below minimum startup temperature of " + str(
-			control['safety']['startuptemp']) + unit + "! Shutting down to prevent firepot overload. " + str(now)
+		body_message = "Grill temperature " + str(error_grill_temp) + unit + \
+			" dropped below minimum startup temperature of " + str(control['safety']['startuptemp']) + unit + \
+			"! Shutting down to prevent firepot overload. " + str(now)
 		channel = 'pifire_error_alerts'
-		query_args = {"value1": str(control['safety']['startuptemp'])}
+		query_args = {
+			"value1": str(control['safety']['startuptemp']),
+			"value2": str(error_grill_temp),
+		}
 		eventLogger.info(body_message)
 	elif "Grill_Error_03" in notify_event:
 		control = read_control()
 		title_message = "Grill Error!"
-		body_message = "Grill temperature dropped below minimum startup temperature of " + str(
-			control['safety']['startuptemp']) + unit + "! Starting a re-ignite attempt, per user settings."
+		body_message = "Grill temperature " + str(error_grill_temp) + unit + \
+			" dropped below minimum startup temperature of " + str(control['safety']['startuptemp']) + unit + \
+			"! Starting a re-ignite attempt, per user settings."
 		channel = 'pifire_error_alerts'
-		query_args = {"value1": str(control['safety']['startuptemp'])}
+		query_args = {
+			"value1": str(control['safety']['startuptemp']),
+			"value2": str(error_grill_temp),
+		}
 		eventLogger.info(body_message)
 	elif "Grill_Warning" in notify_event:
 		title_message = "Grill Warning!"


### PR DESCRIPTION
This updates the over/under temp notifications to include the temperature that triggered it in the message.  This is useful in general, but especially if trying to determine if the failure was caused by a real temp change, or a faulty sensor reading.