### PR TITLE
Extend TempQueue to all physical probes

### DIFF
--- a/probes/ads1015_adafruit.py
+++ b/probes/ads1015_adafruit.py
@@ -79,7 +79,7 @@ class ADSDevice():
 	def get_status(self):
 		return self.status
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=True):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/ads1115.py
+++ b/probes/ads1115.py
@@ -72,7 +72,7 @@ class ADSDevice():
 	def get_status(self):
 		return self.status
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=True):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/ads1115_adafruit.py
+++ b/probes/ads1115_adafruit.py
@@ -80,7 +80,7 @@ class ADSDevice():
 	def get_status(self):
 		return self.status
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=True):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/base.py
+++ b/probes/base.py
@@ -28,6 +28,16 @@ from probes.temp_queue import TempQueue
 '''
 
 class ProbeInterface:
+	def __init_subclass__(cls, *, uses_temp_queue=None, **kwargs):
+		super().__init_subclass__(**kwargs)
+		if uses_temp_queue is None:
+			raise TypeError(
+				'ProbeInterface subclasses must declare '
+				'uses_temp_queue=True or uses_temp_queue=False'
+			)
+		if not isinstance(uses_temp_queue, bool):
+			raise TypeError('uses_temp_queue must be True or False')
+		cls.uses_temp_queue = uses_temp_queue
 
 	def __init__(self, probe_info, device_info, units):
 		self.units = units 
@@ -93,8 +103,9 @@ class ProbeInterface:
 	def _build_ports(self):
 		''' Build ports objects. '''
 		self.port_queues = {}
-		for port in self.port_map:
-			self.port_queues[port] = TempQueue(qlength=10, units=self.units)
+		if self.uses_temp_queue:
+			for port in self.port_map:
+				self.port_queues[port] = TempQueue(qlength=10, units=self.units)
 
 	def _temp_to_resistance(self, temp, probe_profile):
 		'''
@@ -204,15 +215,9 @@ class ProbeInterface:
 			''' Convert Voltage to Temperature and Tr '''
 			port_values[port], self.output_data['tr'][self.port_map[port]] = self._voltage_to_temp(port_values[port], self.probe_profiles[port], port=port)
 
-			''' Enqueue the Temperature Readings to Port Queues '''
-			if port_values[port] == None:
-				''' If the read value is None, pass that to the output instead of adding to the queue '''
-				output_value = None
-			else:
-				self.port_queues[port].enqueue(port_values[port])
-				output_value = self.port_queues[port].average() 
+			output_value = port_values[port]
 
-			''' Get average temperature from the queue and store it in the output data structure'''
+			''' Store converted temperature in the output data structure '''
 			if port == self.primary_port:
 				self.output_data['primary'][self.port_map[port]] = output_value
 			elif port in self.food_ports:
@@ -225,8 +230,35 @@ class ProbeInterface:
 		
 		return self.output_data
 
+	def apply_temp_queue(self, output_data):
+		'''Apply this device's probe values to its per-port TempQueue.'''
+		if not self.uses_temp_queue:
+			return output_data
+
+		for port, label in self.port_map.items():
+			if port == self.primary_port:
+				group = 'primary'
+			elif port in self.food_ports:
+				group = 'food'
+			elif port in self.aux_ports:
+				group = 'aux'
+			else:
+				continue
+
+			if label not in output_data[group]:
+				continue
+
+			value = output_data[group][label]
+			if value is None:
+				continue
+
+			output_data[group][label] = self.port_queues[port].enqueue(value)
+
+		return output_data
+
 	def update_units(self, units):
 		self.units = 'C' if units == 'C' else 'F'
+		self._build_ports()
 		self._init_device()
 
 	def set_profiles(self, probe_info):

--- a/probes/bt_ibbq.py
+++ b/probes/bt_ibbq.py
@@ -352,7 +352,7 @@ class iBBQ_Device():
 		self.status['hardware_id'] = self.hardware_id
 		return self.status
 	
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 	def __init__(self, probe_info, device_info, units):
 		self.hardware_id = device_info['config'].get('hardware_id', None)
 		if self.hardware_id == '':

--- a/probes/bt_ibbq_alt.py
+++ b/probes/bt_ibbq_alt.py
@@ -247,7 +247,7 @@ class iBBQ_Device:
 		return self.status
 
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 	def __init__(self, probe_info, device_info, units):
 		self.hardware_id = device_info['config'].get('hardware_id', None)
 		if self.hardware_id == '':

--- a/probes/bt_igrill_alt.py
+++ b/probes/bt_igrill_alt.py
@@ -432,7 +432,7 @@ class iGrill_Device:
 			return self.status
 
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 	def __init__(self, probe_info, device_info, units):
 		self.hardware_id = device_info['config'].get('hardware_id', None)
 		self.debug_enabled = _to_bool(device_info['config'].get('debug', IGRILL_DEBUG_DEFAULT), default=IGRILL_DEBUG_DEFAULT)

--- a/probes/bt_meater.py
+++ b/probes/bt_meater.py
@@ -438,7 +438,7 @@ class Meater_Device():
 		self.status['probe_id'] = str(self.probe_id)	
 		return self.status
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 	def __init__(self, probe_info, device_info, units):
 		self.hardware_id = device_info['config'].get('hardware_id', None)
 		if self.hardware_id == '':

--- a/probes/bt_meater_alt.py
+++ b/probes/bt_meater_alt.py
@@ -558,7 +558,7 @@ class Meater_Device:
 			return self.status
 
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 	def __init__(self, probe_info, device_info, units):
 		self.hardware_id = device_info['config'].get('hardware_id', None)
 		if self.hardware_id == '':

--- a/probes/bt_meater_exp.py
+++ b/probes/bt_meater_exp.py
@@ -622,7 +622,7 @@ class Meater_Device():
 		self.status['hardware_id'] = self.address
 		return self.status
 	
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 	def __init__(self, probe_info, device_info, units):
 		self.hardware_id = device_info['config'].get('hardware_id', None)
 		if self.hardware_id == '':

--- a/probes/disabled.py
+++ b/probes/disabled.py
@@ -32,7 +32,7 @@ from probes.base import ProbeInterface
 *****************************************
 '''
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/ds18b20.py
+++ b/probes/ds18b20.py
@@ -121,7 +121,7 @@ class DS18B20_Device():
 		self.status['ready'] = self.initialized
 		return self.status
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=True):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/main.py
+++ b/probes/main.py
@@ -74,6 +74,7 @@ class ProbesMain:
 		}
 		for device in self.probe_device_list:
 			device_data = device.read_all_ports(output_data)
+			device_data = device.apply_temp_queue(device_data)
 			for group in device_data:
 				for probe in device_data[group]:
 					output_data[group][probe] = device_data[group][probe]

--- a/probes/max31865.py
+++ b/probes/max31865.py
@@ -189,7 +189,7 @@ class RTDDevice():
 	def get_status(self):
 		return self.status
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=True):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/max31865_adafruit.py
+++ b/probes/max31865_adafruit.py
@@ -93,7 +93,7 @@ class RTDDevice():
 	def get_status(self):
 		return self.status
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=True):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/mcp9600_adafruit.py
+++ b/probes/mcp9600_adafruit.py
@@ -73,7 +73,7 @@ class KTTDevice():
 	def get_status(self):
 		return self.status
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=True):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/prototype.py
+++ b/probes/prototype.py
@@ -98,7 +98,7 @@ class ProtoDevice():
 	def get_status(self):
 		return self.status
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=True):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/virtual_average.py
+++ b/probes/virtual_average.py
@@ -35,7 +35,7 @@ from statistics import mean
 *****************************************
 '''
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/virtual_highest.py
+++ b/probes/virtual_highest.py
@@ -34,7 +34,7 @@ from probes.base import ProbeInterface
 *****************************************
 '''
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/virtual_lowest.py
+++ b/probes/virtual_lowest.py
@@ -34,7 +34,7 @@ from probes.base import ProbeInterface
 *****************************************
 '''
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)

--- a/probes/virtual_median.py
+++ b/probes/virtual_median.py
@@ -35,7 +35,7 @@ from statistics import median
 *****************************************
 '''
 
-class ReadProbes(ProbeInterface):
+class ReadProbes(ProbeInterface, uses_temp_queue=False):
 
 	def __init__(self, probe_info, device_info, units):
 		super().__init__(probe_info, device_info, units)


### PR DESCRIPTION
The ADC probe implementations already use TempQueue to provide more stable temperature readings and reject outliers, but other physical probes return their readings without the same handling.

This change moves TempQueue handling into the shared probe pipeline and requires each probe implementation to explicitly declare whether it should be used. Directly sampled physical probes enable it, while Bluetooth, virtual, and disabled probes retain their existing behavior.